### PR TITLE
refactor: remove messages from fromFixture

### DIFF
--- a/source/from-fixture-spec.ts
+++ b/source/from-fixture-spec.ts
@@ -28,34 +28,12 @@ describe("fromFixture", () => {
     ]);
   });
 
-  it("should create an invalid test with a message", () => {
-    const test = fromFixture(
-      stripIndent`
-        const name = "alice";
-                     ~~~~~~~ [1]
-      `,
-      { 1: "Whoops!" }
-    );
-    expect(test).to.have.property("code", `const name = "alice";`);
-    expect(test).to.have.property("errors");
-    expect(test.errors).to.deep.equal([
-      {
-        column: 14,
-        endColumn: 21,
-        endLine: 1,
-        line: 1,
-        message: "Whoops!",
-      },
-    ]);
-  });
-
   it("should create an invalid test with options", () => {
     const test = fromFixture(
       stripIndent`
         const name = "alice";
                      ~~~~~~~ [whoops]
       `,
-      undefined,
       {
         filename: "test.ts",
         output: stripIndent`

--- a/source/from-fixture.ts
+++ b/source/from-fixture.ts
@@ -10,7 +10,6 @@ export function fromFixture<
   TOptions extends unknown[] = unknown[]
 >(
   fixture: string,
-  messages: Record<string | number, string> = {},
   options: Omit<
     eslint.InvalidTestCase<TMessageIds, TOptions>,
     "code" | "errors"
@@ -18,14 +17,11 @@ export function fromFixture<
 ): eslint.InvalidTestCase<TMessageIds, TOptions> {
   return {
     ...options,
-    ...parseFixture(fixture, messages),
+    ...parseFixture(fixture),
   };
 }
 
-function parseFixture<TMessageIds extends string>(
-  fixture: string,
-  messages: Record<string | number, string>
-) {
+function parseFixture<TMessageIds extends string>(fixture: string) {
   const errorRegExp = /^(\s*)(~+)\s*\[(\w+)\]\s*$/;
   const lines: string[] = [];
   const errors: eslint.TestCaseError<TMessageIds>[] = [];
@@ -45,11 +41,7 @@ function parseFixture<TMessageIds extends string>(
         line: length,
       };
       const key = match[3];
-      if (messages[key]) {
-        error.message = messages[key];
-      } else {
-        error.messageId = key;
-      }
+      error.messageId = key;
       errors.push(error as eslint.TestCaseError<TMessageIds>);
     } else {
       lines.push(line);


### PR DESCRIPTION
BREAKING CHANGE:

The option to pass custom messages is removed, `fromFixture` only verifies message IDs.


