### PR TITLE
feat: mark ts 5.x as supported peer-dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "optionalDependencies": {},
   "peerDependencies": {
     "eslint": "^8.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^4.0.0 || ^5.0.0"
   },
   "private": false,
   "publishConfig": {


### PR DESCRIPTION
TS 5.0 is not really a major as TS team does not follow the semver at all. It seems reasonable to mark any 5.x version as an acceptable peer version.

By the way: I was also wondering if I should bump all the other imports of TS to move them all to TS 5.x. But so far I just changed the peer one.